### PR TITLE
Override browser defaults

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,5 +1,13 @@
 @import url('https://fonts.googleapis.com/css2?family=Exo+2:wght@300&display=swap');
 
+* {
+    border: 0;
+    outline: 0;
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+}
+
 body {
     background: #6fadd1;
     margin: 0;


### PR DESCRIPTION
It's convention to do this at the start of every css file in order to override browser defaults. This means that some of your padding stuff will have to be redone but this is the standard method. `box-sizing: border-box` makes setting dimensions (height, width) include the padding. The reason the size of the hero section was off was because the true height was `100vh+padding` not `100vh` including padding. Hope this helps wnag.